### PR TITLE
Fix crashing H and QT tasks

### DIFF
--- a/F3K_TRAINING/task_h.lua
+++ b/F3K_TRAINING/task_h.lua
@@ -103,7 +103,7 @@ function taskH.flyingState()
 			if t ~= taskH.previousTime then
 				local sec = t % 60
 				if sec > 44 or sec == 30 then
-					taskH.playNumber( sec, (sec == 30) and OpenTX.SECONDS or 0, 0 )
+					playNumber( sec, (sec == 30) and OpenTX.SECONDS or 0, 0 )
 					taskH.previousTime = t
 				end
 			end

--- a/F3K_TRAINING/task_qt.lua
+++ b/F3K_TRAINING/task_qt.lua
@@ -83,7 +83,7 @@ function taskQT.flyingState()
 			local t = taskQT.timer2.getVal()
 			if t ~= taskQT.previousTime then
 				if t > 0 and t <= 30 then
-					taskQT.playNumber( t, 0, 0 )
+					playNumber( t, 0, 0 )
 					taskQT.previousTime = t
 				end
 			end


### PR DESCRIPTION
Play file is abstracted to taskBase but playNumber is not, so taskH.playNumber is invalid, playNumber has to be called