### PR TITLE
Fix duration announcement on EdgeTX

### DIFF
--- a/F3K_TRAINING/besttaskbase.lua
+++ b/F3K_TRAINING/besttaskbase.lua
@@ -33,7 +33,7 @@ function taskBase.landedState()
 			if remaining < taskBase.MAX_FLIGHT_TIME then
 				taskBase.timer2.start( remaining )
 				taskBase.playSound( 'remaining' )
-				taskBase.playTime( remaining )
+				taskBase.playRemainingTime( remaining )
 			else
 				taskBase.timer2.start()
 			end

--- a/F3K_TRAINING/lasttaskbase.lua
+++ b/F3K_TRAINING/lasttaskbase.lua
@@ -61,7 +61,7 @@ function taskBase.landedState()
 			if remaining < taskBase.MAX_FLIGHT_TIME then
 				taskBase.timer2.start( remaining )
 				taskBase.playSound( 'remaining' )
-				taskBase.playTime( remaining )
+				taskBase.playRemainingTime( remaining )
 			else
 				taskBase.timer2.start()
 			end

--- a/F3K_TRAINING/opentx_srv.lua
+++ b/F3K_TRAINING/opentx_srv.lua
@@ -14,7 +14,6 @@
 
 
 local openTX = {}
-openTX.OS_NAME = 'OpenTX'
 
 
 local function createLcdLayer()
@@ -173,10 +172,7 @@ if not ok then
 end
 
 ok, msg = pcall( function()
-	local ver, radio, majorVer, minorVer, rev, osname = getVersion()
-	if type( osname ) == 'string' then
-		openTX.OS_NAME = osname
-	end
+	local ver = getVersion()
 
 	local major, minor, patch = ver:match("^(%d+)%.(%d+)%.?(%d*)$")
 	print("Read version " .. major .. '.' .. minor .. '.' .. patch)

--- a/F3K_TRAINING/opentx_srv.lua
+++ b/F3K_TRAINING/opentx_srv.lua
@@ -14,7 +14,6 @@
 
 
 local openTX = {}
-openTX.IS_EDGETX = false
 openTX.OS_NAME = 'OpenTX'
 
 
@@ -177,7 +176,6 @@ ok, msg = pcall( function()
 	local ver, radio, majorVer, minorVer, rev, osname = getVersion()
 	if type( osname ) == 'string' then
 		openTX.OS_NAME = osname
-		openTX.IS_EDGETX = (osname == 'EdgeTX')
 	end
 
 	local major, minor, patch = ver:match("^(%d+)%.(%d+)%.?(%d*)$")

--- a/F3K_TRAINING/opentx_srv.lua
+++ b/F3K_TRAINING/opentx_srv.lua
@@ -14,6 +14,8 @@
 
 
 local openTX = {}
+openTX.IS_EDGETX = false
+openTX.OS_NAME = 'OpenTX'
 
 
 local function createLcdLayer()
@@ -172,7 +174,11 @@ if not ok then
 end
 
 ok, msg = pcall( function()
-	local ver = getVersion()
+	local ver, radio, majorVer, minorVer, rev, osname = getVersion()
+	if type( osname ) == 'string' then
+		openTX.OS_NAME = osname
+		openTX.IS_EDGETX = (osname == 'EdgeTX')
+	end
 
 	local major, minor, patch = ver:match("^(%d+)%.(%d+)%.?(%d*)$")
 	print("Read version " .. major .. '.' .. minor .. '.' .. patch)

--- a/F3K_TRAINING/task_d.lua
+++ b/F3K_TRAINING/task_d.lua
@@ -70,7 +70,7 @@ function taskD.flyingState()
 			else
 				taskD.initFlightTimer()
 				taskD.playSound( 'nxttarget' )
-				taskD.playTime( taskD.MAX_FLIGHT_TIME )
+				taskD.playRemainingTime( taskD.MAX_FLIGHT_TIME )
 				taskD.state = 4
 			end
 		end

--- a/F3K_TRAINING/task_d2.lua
+++ b/F3K_TRAINING/task_d2.lua
@@ -89,7 +89,7 @@ function taskD2.flyingState()
 						taskD2.initFlightTimer()
 
 						taskD2.playSound( 'nxttarget' )
-						taskD2.playTime( taskD2.MAX_FLIGHT_TIME )
+						taskD2.playRemainingTime( taskD2.MAX_FLIGHT_TIME )
 					end
 				end
 			end

--- a/F3K_TRAINING/task_dold.lua
+++ b/F3K_TRAINING/task_dold.lua
@@ -89,7 +89,7 @@ function taskD.flyingState()
 						taskD.initFlightTimer()
 
 						taskD.playSound( 'nxttarget' )
-						taskD.playTime( taskD.MAX_FLIGHT_TIME )
+						taskD.playRemainingTime( taskD.MAX_FLIGHT_TIME )
 					end
 				end
 			end

--- a/F3K_TRAINING/task_f.lua
+++ b/F3K_TRAINING/task_f.lua
@@ -64,7 +64,7 @@ function taskF.landedState()
 			if remaining < taskF.MAX_FLIGHT_TIME then
 				taskF.timer2.start( remaining )
 				taskF.playSound( 'remaining' )
-				taskF.playTime( remaining )
+				taskF.playRemainingTime( remaining )
 			else
 				taskF.timer2.start()
 			end

--- a/F3K_TRAINING/task_h.lua
+++ b/F3K_TRAINING/task_h.lua
@@ -103,7 +103,11 @@ function taskH.flyingState()
 			if t ~= taskH.previousTime then
 				local sec = t % 60
 				if sec > 44 or sec == 30 then
-					playNumber( sec, (sec == 30) and OpenTX.SECONDS or 0, 0 )
+					if playDuration then
+						playDuration( sec, 0 )
+					else
+						playNumber( sec, OpenTX.SECONDS, 0 )
+					end
 					taskH.previousTime = t
 				end
 			end

--- a/F3K_TRAINING/task_k.lua
+++ b/F3K_TRAINING/task_k.lua
@@ -72,7 +72,7 @@ function taskK.flyingState()
 			else
 				taskK.initFlightTimer()
 				taskK.playSound( 'nxttarget' )
-				taskK.playTime( taskK.MAX_FLIGHT_TIME )
+				taskK.playRemainingTime( taskK.MAX_FLIGHT_TIME )
 				taskK.state = 4
 			end
 		end

--- a/F3K_TRAINING/task_l.lua
+++ b/F3K_TRAINING/task_l.lua
@@ -68,7 +68,7 @@ function taskL.flyingState()
 			else
 				taskL.initFlightTimer()
 				taskL.playSound( 'nxttarget' )
-				taskL.playTime( taskL.MAX_FLIGHT_TIME )
+				taskL.playRemainingTime( taskL.MAX_FLIGHT_TIME )
 				taskL.state = 4
 			end
 		end

--- a/F3K_TRAINING/task_m.lua
+++ b/F3K_TRAINING/task_m.lua
@@ -74,7 +74,7 @@ function taskM.flyingState()
 			else
 				taskM.initFlightTimer()
 				taskM.playSound( 'nxttarget' )
-				taskM.playTime( taskM.MAX_FLIGHT_TIME )
+				taskM.playRemainingTime( taskM.MAX_FLIGHT_TIME )
 				taskM.state = 4
 			end
 		end

--- a/F3K_TRAINING/task_qt.lua
+++ b/F3K_TRAINING/task_qt.lua
@@ -83,7 +83,11 @@ function taskQT.flyingState()
 			local t = taskQT.timer2.getVal()
 			if t ~= taskQT.previousTime then
 				if(t == 30) then
-					playNumber( t, OpenTX.SECONDS, 0)
+					if playDuration then
+						playDuration( t, 0 )
+					else
+						playNumber( t, OpenTX.SECONDS, 0 )
+					end
 					taskQT.previousTime = t
 				elseif t > 0 and t <= 15 then
 					playNumber( t, 0, 0 )
@@ -103,7 +107,7 @@ function taskQT.landedState()
 			if remaining < taskQT.MAX_FLIGHT_TIME then
 				taskQT.timer2.start( remaining )
 				taskQT.playSound( 'remaining' )
-				taskQT.playTime( remaining )
+				taskQT.playRemainingTime( remaining )
 			else
 				taskQT.timer2.start()
 			end

--- a/F3K_TRAINING/taskbase-15min.lua
+++ b/F3K_TRAINING/taskbase-15min.lua
@@ -44,6 +44,11 @@ local taskBase = {
 	-- Some common stuff
 
 function taskBase.playTime( time )
+	if OpenTX.IS_EDGETX and playDuration then
+		playDuration( time, 0 )
+		return
+	end
+
 	local val = math.floor( time / 60 )
 	if val > 0 then
 		taskBase.playSound( 'remaining' )

--- a/F3K_TRAINING/taskbase-15min.lua
+++ b/F3K_TRAINING/taskbase-15min.lua
@@ -43,15 +43,18 @@ local taskBase = {
 
 	-- Some common stuff
 
-function taskBase.playTime( time )
-	if OpenTX.IS_EDGETX and playDuration then
+function taskBase.playRemainingTime( time )
+	if time >= 60 then
+		taskBase.playSound( 'remaining' )
+	end
+
+	if playDuration then
 		playDuration( time, 0 )
 		return
 	end
 
 	local val = math.floor( time / 60 )
 	if val > 0 then
-		taskBase.playSound( 'remaining' )
 		playNumber( val, OpenTX.MINUTES, 0 )
 	end
 	val = time % 60

--- a/F3K_TRAINING/taskbase.lua
+++ b/F3K_TRAINING/taskbase.lua
@@ -44,6 +44,11 @@ local taskBase = {
 	-- Some common stuff
 
 function taskBase.playTime( time )
+	if OpenTX.IS_EDGETX and playDuration then
+		playDuration( time, 0 )
+		return
+	end
+
 	local val = math.floor( time / 60 )
 	if val > 0 then
 		taskBase.playSound( 'remaining' )

--- a/F3K_TRAINING/taskbase.lua
+++ b/F3K_TRAINING/taskbase.lua
@@ -43,15 +43,18 @@ local taskBase = {
 
 	-- Some common stuff
 
-function taskBase.playTime( time )
-	if OpenTX.IS_EDGETX and playDuration then
+function taskBase.playRemainingTime( time )
+	if time >= 60 then
+		taskBase.playSound( 'remaining' )
+	end
+
+	if playDuration then
 		playDuration( time, 0 )
 		return
 	end
 
 	local val = math.floor( time / 60 )
 	if val > 0 then
-		taskBase.playSound( 'remaining' )
 		playNumber( val, OpenTX.MINUTES, 0 )
 	end
 	val = time % 60


### PR DESCRIPTION
In task N when announces the remaining time, it says miliamper and decibel.
It is beacuse EdgeTX changed the the meaning of the constant values.
This change will detect EdgeTX and will invoke the designated system function to say a time.