### PR TITLE
Add basic telemetry values

### DIFF
--- a/F3K_TRAINING/X7/view_c.lua
+++ b/F3K_TRAINING/X7/view_c.lua
@@ -7,12 +7,13 @@
 
 
 local task = dofile( F3K_SCRIPT_PATH .. 'task_c.lua' )
-local display = {}
+local display = dofile( F3K_SCRIPT_PATH .. 'X7/viewbase.lua' )
 
 
 function task.display()
 	lcd.drawText( 2, 2, task.name, 0 )
 	task.timer2.drawReverse( 24, 18, DBLSIZE )
+	display.drawTelemetry()
 
 	lcd.drawLine( 0, 47, 89, 47, SOLID, 2 )
 	lcd.drawLine( 90, 0, 90, 63, SOLID, 2 )

--- a/F3K_TRAINING/X7/view_ff.lua
+++ b/F3K_TRAINING/X7/view_ff.lua
@@ -10,6 +10,7 @@
 
 
 local task = dofile( F3K_SCRIPT_PATH .. 'task_ff.lua' )
+local display = dofile( F3K_SCRIPT_PATH .. 'X7/viewbase.lua' )
 
 
 function task.display()
@@ -18,6 +19,7 @@ function task.display()
 	task.timer1.draw( 24, 18, DBLSIZE )
 	task.timer2.draw( 10, 53, 0 )
 	lcd.drawTimer( 50, 53, getValue( 'clock' ), 0 )
+	display.drawTelemetry()
 
 	lcd.drawLine( 0, 47, 89, 47, SOLID, 2 )
 	lcd.drawLine( 90, 0, 90, 63, SOLID, 2 )

--- a/F3K_TRAINING/X7/view_h.lua
+++ b/F3K_TRAINING/X7/view_h.lua
@@ -13,6 +13,7 @@ local display = dofile( F3K_SCRIPT_PATH .. 'X7/viewbase.lua' )
 function task.display()
 	lcd.drawText( 2, 2, task.name, 0 )
 	task.timer1.draw( 22, 18, DBLSIZE )
+	display.drawTelemetry()
 
 	lcd.drawLine( 0, 47, 79, 47, SOLID, 2 )
 	lcd.drawLine( 80, 0, 80, 63, SOLID, 2 )

--- a/F3K_TRAINING/X7/viewbase.lua
+++ b/F3K_TRAINING/X7/viewbase.lua
@@ -1,9 +1,54 @@
 local display = {}
 
+local sourceIdCache = {}
+
+local function getFirstValue(sourceList)
+	if not sourceList then
+		return nil
+	end
+
+	for _, name in ipairs(sourceList) do
+		local sourceId = sourceIdCache[name]
+		if sourceId == nil then
+			sourceId = getSourceIndex and getSourceIndex(name) or false
+			sourceIdCache[name] = sourceId
+		end
+
+		local value = nil
+		if sourceId and getSourceValue then
+			value = getSourceValue(sourceId)
+		end
+
+		if value == nil then
+			value = getValue(name)
+		end
+
+		if value ~= nil then
+			return value
+		end
+	end
+
+	return nil
+end
+
+function display.drawTelemetry()
+	local modelVoltage = getFirstValue(F3KConfig.MODEL_VOLTAGE)
+	local modelText = (modelVoltage ~= nil and string.format("M:%.1f", modelVoltage)) or "M:-.-"
+	lcd.drawText(0, 38, modelText, 0)
+
+	local radioVoltage = getFirstValue(F3KConfig.RADIO_VOLTAGE)
+	local radioText = (radioVoltage ~= nil and string.format("R:%.1f", radioVoltage)) or "R:-.-"
+	lcd.drawText(28, 38, radioText, 0)
+
+	local altitude = getFirstValue(F3KConfig.HEIGHT)
+	local altitudeText = (altitude ~= nil and string.format("A:%.0f", altitude)) or "A:?"
+	lcd.drawText(56, 38, altitudeText, 0)
+end
 
 function display.drawCommon( task )
 	lcd.drawText( 2, 2, task.name, 0 )
 	task.timer1.draw( 24, 18, DBLSIZE )
+	display.drawTelemetry()
 
 	lcd.drawLine( 0, 47, 89, 47, SOLID, 2 )
 	lcd.drawLine( 90, 0, 90, 63, SOLID, 2 )
@@ -12,6 +57,7 @@ end
 function display.drawCommonLarge( task )
 	lcd.drawText( 2, 2, task.name, 0 )
 	task.timer1.draw( 22, 18, DBLSIZE )
+	display.drawTelemetry()
 
 	lcd.drawLine( 0, 47, 83, 47, SOLID, 2 )
 	lcd.drawLine( 84, 0, 84, 63, SOLID, 2 )

--- a/F3K_TRAINING/custom.lua
+++ b/F3K_TRAINING/custom.lua
@@ -16,6 +16,9 @@ local PRELAUNCH_SWITCH = 'se' 		-- temporary switch on the left
 --local PRELAUNCH_SWITCH = 'sh'		-- temporary switch on the right (or emulator)
 local MENU_SWITCH = 'sc'		-- a 3-pos switch is mandatory here : up=menu; mid=stop; down=run
 local MENU_SCROLL_ENCODER = 'thr'
+local RADIO_VOLTAGE = { 'Batt' }
+local MODEL_VOLTAGE = { 'RxBt', 'Rbt' }
+local HEIGHT = { 'GAlt', 'Valt' }
 
 local SOUND_PATH = F3K_SCRIPT_PATH .. 'sounds/'
 
@@ -95,6 +98,9 @@ return {
 	PRELAUNCH_SWITCH = getFieldInfo( PRELAUNCH_SWITCH ).id,
 	MENU_SCROLL_ENCODER = getFieldInfo( MENU_SCROLL_ENCODER ).id,
 	SOUND_PATH = safeGetSoundPath(SOUND_PATH),
+	RADIO_VOLTAGE = RADIO_VOLTAGE,
+	MODEL_VOLTAGE = MODEL_VOLTAGE,
+	HEIGHT = HEIGHT,
 
 	resetLaunchDetection = resetLaunchDetection,
 	launched = launched,


### PR DESCRIPTION
Add model voltage, radio voltage and model altitude values to the small screen.
The telemetry names are defined as array so is flexible to different types of sensors.
Graupner, Radiomaster and a custom sensor was included and tested.