### PR TITLE
Fix 1234 to not say seconds at minute mark countdown

### DIFF
--- a/F3K_TRAINING/task_h.lua
+++ b/F3K_TRAINING/task_h.lua
@@ -103,11 +103,7 @@ function taskH.flyingState()
 			if t ~= taskH.previousTime then
 				local sec = t % 60
 				if sec > 44 or sec == 30 then
-					if playDuration then
-						playDuration( sec, 0 )
-					else
-						playNumber( sec, OpenTX.SECONDS, 0 )
-					end
+					playNumber( sec, 0, 0 )
 					taskH.previousTime = t
 				end
 			end


### PR DESCRIPTION
instead of saying "45 seconds 44 seconds 43 seconds..." say only "45 44 43 ..." at round minute marks
Too much play overdead, can't keep up if other announcements happens.