### PR TITLE
Multiple "time remaining" announcements

### DIFF
--- a/F3K_TRAINING/taskbase-15min.lua
+++ b/F3K_TRAINING/taskbase-15min.lua
@@ -44,10 +44,6 @@ local taskBase = {
 	-- Some common stuff
 
 function taskBase.playRemainingTime( time )
-	if time >= 60 then
-		taskBase.playSound( 'remaining' )
-	end
-
 	if playDuration then
 		playDuration( time, 0 )
 		return

--- a/F3K_TRAINING/taskbase.lua
+++ b/F3K_TRAINING/taskbase.lua
@@ -49,6 +49,8 @@ function taskBase.playRemainingTime( time )
 		return
 	end
 
+	// this is a legacy code, OpenTX 2.2+ has playDuration
+	// The OpenTX.MINUTES and OpenTX.SECONDS constants are no longer suitable
 	local val = math.floor( time / 60 )
 	if val > 0 then
 		playNumber( val, OpenTX.MINUTES, 0 )

--- a/F3K_TRAINING/taskbase.lua
+++ b/F3K_TRAINING/taskbase.lua
@@ -44,10 +44,6 @@ local taskBase = {
 	-- Some common stuff
 
 function taskBase.playRemainingTime( time )
-	if time >= 60 then
-		taskBase.playSound( 'remaining' )
-	end
-
 	if playDuration then
 		playDuration( time, 0 )
 		return


### PR DESCRIPTION
I know, I added this but the "time remaining" announcement is duplicated for several tasks, so better to remove and add explicitly when is needed.